### PR TITLE
chore: remove typo in create-effect-app CLI option description

### DIFF
--- a/.changeset/mean-garlics-speak.md
+++ b/.changeset/mean-garlics-speak.md
@@ -1,0 +1,5 @@
+---
+"create-effect-app": patch
+---
+
+Fixes a typo in the description of the template option of ⁠create-effect-app.

--- a/.changeset/mean-garlics-speak.md
+++ b/.changeset/mean-garlics-speak.md
@@ -2,4 +2,4 @@
 "create-effect-app": patch
 ---
 
-Fixes a typo in the description of the template option of ⁠create-effect-app.
+Fixes a typo in the description of the `template` option of ⁠`create-effect-app`.

--- a/packages/create-effect-app/src/Cli.ts
+++ b/packages/create-effect-app/src/Cli.ts
@@ -363,7 +363,7 @@ const getUserInput = Prompt.select<"example" | "template">({
     case "example": {
       return Prompt.all({
         example: Prompt.select<Example>({
-          message: "What project template should be used?",
+          message: "What project example should be used?",
           choices: [
             {
               title: "HTTP Server",

--- a/packages/create-effect-app/src/Cli.ts
+++ b/packages/create-effect-app/src/Cli.ts
@@ -41,7 +41,7 @@ const exampleType = Options.choice("example", examples).pipe(
 const templateType = Options.choice("template", templates).pipe(
   Options.withAlias("t"),
   Options.withDescription(
-    "The name of an official Effect example to use to bootstrap the application"
+    "The name of an official Effect template to use to bootstrap the application"
   )
 )
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Fixes a small typo in the `template` option of the CLI.