### PR TITLE
chore: update vitest version for latest peer dep requirements

### DIFF
--- a/.changeset/tidy-games-visit.md
+++ b/.changeset/tidy-games-visit.md
@@ -1,0 +1,5 @@
+---
+"create-effect-app": patch
+---
+
+update @effect/vitest peer dep vitest version

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
     "tsx": "^4.17.0",
     "typescript": "^5.6.2",
-    "vitest": "^2.0.5"
+    "vitest": "^3.2.0"
   },
   "effect": {
     "generateExports": {

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -52,7 +52,7 @@
     "tsup": "^8.2.4",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "vitest": "^2.0.5"
+    "vitest": "^3.2.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/templates/monorepo/package.json
+++ b/templates/monorepo/package.json
@@ -46,12 +46,9 @@
     "glob": "^11.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
-    "vitest": "^2.1.4"
+    "vitest": "^3.2.0"
   },
   "pnpm": {
-    "overrides": {
-      "vitest": "^2.0.5"
-    },
     "patchedDependencies": {
       "@changesets/get-github-info@0.6.0": "patches/@changesets__get-github-info@0.6.0.patch",
       "@changesets/assemble-release-plan@6.0.5": "patches/@changesets__assemble-release-plan@6.0.5.patch",


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes the unmeet peer dependency warning when installing deps the first time when creating a template app.

```
 WARN  Issues with peer dependencies found
.
└─┬ @effect/vitest 0.25.0
  └── ✕ unmet peer vitest@^3.2.0: found 2.1.9
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
