### PR TITLE
chore: update the Node.js version to 24.5.0

### DIFF
--- a/.changeset/tasty-lemons-repeat.md
+++ b/.changeset/tasty-lemons-repeat.md
@@ -1,0 +1,5 @@
+---
+'create-effect-app': patch
+---
+
+update the Node.js version to 24.5.0

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: The version of Node.js to install
     required: true
-    default: 20.14.0
+    default: 24.5.0
 
 runs:
   using: composite

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.14.0
+          node-version: 24.5.0
       - name: Install dependencies
         run: pnpm install
       - run: pnpm lint
@@ -99,7 +99,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.14.0
+          node-version: 24.5.0
       - name: Install dependencies
         run: pnpm install
       - run: pnpm lint

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,5 +1,5 @@
 import * as Fs from "node:fs"
-import Package from "../packages/create-effect-app/package.json" assert { type: "json" }
+import Package from "../packages/create-effect-app/package.json" with { type: "json" }
 
 const tpl = Fs.readFileSync("./scripts/version.template.txt").toString("utf8")
 

--- a/templates/monorepo/.github/actions/setup/action.yml
+++ b/templates/monorepo/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: The version of Node.js to install
     required: true
-    default: 20.14.0
+    default: 24.5.0
 
 runs:
   using: composite


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Update the Node version used in GitHub Actions to the current version (`24.5.0`). 

## Related

- Related Issue #
- Closes #
