### PR TITLE
fix: re-apply patch for @changesets/assemble-release-plan@6.0.9

### DIFF
--- a/.changeset/mean-rabbits-run.md
+++ b/.changeset/mean-rabbits-run.md
@@ -1,0 +1,5 @@
+---
+'create-effect-app': patch
+---
+
+re-apply patch for @changesets/assemble-release-plan@6.0.9 in monorepo template

--- a/templates/monorepo/package.json
+++ b/templates/monorepo/package.json
@@ -51,7 +51,7 @@
   "pnpm": {
     "patchedDependencies": {
       "@changesets/get-github-info@0.6.0": "patches/@changesets__get-github-info@0.6.0.patch",
-      "@changesets/assemble-release-plan@6.0.5": "patches/@changesets__assemble-release-plan@6.0.5.patch",
+      "@changesets/assemble-release-plan@6.0.9": "patches/@changesets__assemble-release-plan@6.0.9.patch",
       "babel-plugin-annotate-pure-calls@0.4.0": "patches/babel-plugin-annotate-pure-calls@0.4.0.patch"
     }
   }

--- a/templates/monorepo/patches/@changesets__assemble-release-plan@6.0.9.patch
+++ b/templates/monorepo/patches/@changesets__assemble-release-plan@6.0.9.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
-index 4f7b5e5b37bb05874a5c1d8e583e29d4a9593ecf..980ead81554a8d925b6366e1644f3be03765398e 100644
+index e07ba6e793021b6cfdec898afca517e293386ddb..88d80a95fbe739996918ef4883601b4388926123 100644
 --- a/dist/changesets-assemble-release-plan.cjs.js
 +++ b/dist/changesets-assemble-release-plan.cjs.js
-@@ -237,7 +237,7 @@ function determineDependents({
+@@ -215,7 +215,7 @@ function determineDependents({
              preInfo,
              onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
            })) {
@@ -12,10 +12,10 @@ index 4f7b5e5b37bb05874a5c1d8e583e29d4a9593ecf..980ead81554a8d925b6366e1644f3be0
              switch (depType) {
                case "dependencies":
 diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
-index a327d9e4c709a6698f505d60d8bbf0046d4bde74..eb00fec7262280fb4876165c942212abc6b25efb 100644
+index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..b62b66628d8887618b02ee35359faf70cbe685ad 100644
 --- a/dist/changesets-assemble-release-plan.esm.js
 +++ b/dist/changesets-assemble-release-plan.esm.js
-@@ -226,7 +226,7 @@ function determineDependents({
+@@ -204,7 +204,7 @@ function determineDependents({
              preInfo,
              onlyUpdatePeerDependentsWhenOutOfRange: config.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange
            })) {


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

This PR re-applies patch for `@changesets/assemble-release-plan@6.0.9` in monorepo template

## Related

- Closes #61 
