### PR TITLE
fix: replace `HttpApi.empty` with `HttpApi.make('api')` in http-server example

### DIFF
--- a/examples/http-server/src/Api.ts
+++ b/examples/http-server/src/Api.ts
@@ -3,7 +3,7 @@ import { AccountsApi } from "./Accounts/Api.js"
 import { GroupsApi } from "./Groups/Api.js"
 import { PeopleApi } from "./People/Api.js"
 
-export class Api extends HttpApi.empty
+export class Api extends HttpApi.make('api')
   .add(AccountsApi)
   .add(GroupsApi)
   .add(PeopleApi)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

This patch fixes an issue with the `http-server` example:

> Argument of type 'typeof Api' is not assignable to parameter of type 'HttpApi<string, Any, unknown, unknown>

## Related


- Related Issue #62

