### PR TITLE
fix: update '@opentelemetry/exporter-trace-otlp-http' in http-server example

### DIFF
--- a/examples/http-server/package.json
+++ b/examples/http-server/package.json
@@ -34,7 +34,7 @@
     "@eslint/compat": "1.1.1",
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.10.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.54.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^2.0.1",
     "@opentelemetry/sdk-trace-node": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^8.4.0",


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

Missed updating this package in #80

With the current version, running `pnpm check` in the created app leads to this error:

> Argument of type 'OTLPTraceExporter' is not assignable to parameter of type 'SpanExporter'

## Related

- Related Issue #80 

