### PR TITLE
fix: add publishConfig to server package in monorepo template

### DIFF
--- a/templates/monorepo/packages/server/package.json
+++ b/templates/monorepo/packages/server/package.json
@@ -9,6 +9,10 @@
     "url": "<PLACEHOLDER>",
     "directory": "packages/server"
   },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
   "scripts": {
     "codegen": "build-utils prepare-v2",
     "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v2",


### PR DESCRIPTION


## Type

<!--
What type of change is this? Please check all applicable.
-->

- [x] Bug Fix

## Description

The `packages/server` package in the `monorepo` template does not have the `publishConfig` like the other 2.


This leads to the following error when changesets tries to publish it to npm as it wants to publish it as a private package:

> 🦋  error an error occurred while publishing @beeman-playground/server: E402 402 Payment Required - PUT https://registry.npmjs.org/@beeman-playground%2fserver - You must sign up for private packages 

<img width="1431" height="939" alt="image" src="https://github.com/user-attachments/assets/083ef3be-1718-443f-8227-1506e0347404" />

## Related


- Related Issue #
- Closes #
