### PR TITLE
fix: linting error in http-server example

### DIFF
--- a/examples/http-server/src/Api.ts
+++ b/examples/http-server/src/Api.ts
@@ -3,7 +3,7 @@ import { AccountsApi } from "./Accounts/Api.js"
 import { GroupsApi } from "./Groups/Api.js"
 import { PeopleApi } from "./People/Api.js"
 
-export class Api extends HttpApi.make('api')
+export class Api extends HttpApi.make("api")
   .add(AccountsApi)
   .add(GroupsApi)
   .add(PeopleApi)


### PR DESCRIPTION
## Type

- [x] Bug Fix

## Description

This PR fixes a linting error in the http-server example.
 
## Related

- Related Issue #84 (introduced here)


It would be good to have a CI job in this repo that makes sure code gets linted before we merge it.
Edit: looks like [it's there](https://github.com/Effect-TS/examples/blob/main/.github/workflows/check.yml#L35) but it somehow didn't catch this issue.
